### PR TITLE
fix doc bugs

### DIFF
--- a/src/components/textfield/README.md
+++ b/src/components/textfield/README.md
@@ -22,7 +22,7 @@ var vm = new Vue({
 
 ### Full width
 ```html
-<mdc-textfield v-model="text" label="Hint text" />
+<mdc-textfield v-model="text" fullwidth label="Hint text" />
 ```
 
 ### Multiline

--- a/src/components/textfield/README.md
+++ b/src/components/textfield/README.md
@@ -1,4 +1,4 @@
-## Textfields
+## Textfield
 
 ### Single-line
 ```html

--- a/src/components/textfield/README.md
+++ b/src/components/textfield/README.md
@@ -24,10 +24,10 @@ var vm = new Vue({
 ```html
 <mdc-textfield v-model="text" label="Hint text" />
 ```
-  
+
 ### Multiline
 ```html
-<mdc-textfield v-model="text" label="Hint text" multiline rows="8", cols="40" />
+<mdc-textfield v-model="text" label="Hint text" multiline rows="8" cols="40" />
 ```
 
 ### Validation


### PR DESCRIPTION
The comma in [this comment](https://github.com/stasson/vue-mdc-adapter/pull/39/commits/625cc0089047eb460dadec0793ebe11dd2e7f2b1) cause `Uncaught DOMException: Failed to execute 'setAttribute' on 'Element': ',' is not a valid attribute name.`

And [this](https://github.com/stasson/vue-mdc-adapter/pull/39/commits/9baea4abf4b2b4c99fc8ee4a8a7f880d4d4489a6) fix the problem that user can't position chapter Textfield by clicking link in [content of table](https://github.com/stasson/vue-mdc-adapter/wiki/components).