### PR TITLE
Fix toolbar menu href

### DIFF
--- a/src/components/toolbar/mdc-toolbar-icon-menu.vue
+++ b/src/components/toolbar/mdc-toolbar-icon-menu.vue
@@ -1,5 +1,5 @@
 <template>
-  <a href="#" class="material-icons mdc-toolbar__icon--menu"
+  <a class="material-icons mdc-toolbar__icon--menu"
     @click="dispatchEvent"
   >
     <slot>menu</slot>
@@ -14,3 +14,9 @@ export default {
   mixins: [DispatchEventMixin]
 }
 </script>
+
+<style lang="css">
+.mdc-toolbar__icon--menu:hover {
+  cursor: pointer;
+}
+</style>

--- a/src/components/toolbar/mdc-toolbar-icon.vue
+++ b/src/components/toolbar/mdc-toolbar-icon.vue
@@ -12,8 +12,14 @@ import {DispatchEventMixin} from '../util'
 export default {
   name: 'mdc-toolbar-icon',
   props: {
-    'href': { type: String, default: '#' }
+    'href': { type: String }
   },
   mixins: [DispatchEventMixin]
 }
 </script>
+
+<style lang="css">
+.mdc-toolbar__icon:hover {
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
[Vue-router](https://router.vuejs.org/en/essentials/history-mode.html) use hash to simulate url by default. So a `<a href="#">` link would navigate to index when it was clicked.