### PR TITLE
fix(components): fix missing `name` option in the Vue components

### DIFF
--- a/components/checkbox/mdc-checkbox.vue
+++ b/components/checkbox/mdc-checkbox.vue
@@ -29,6 +29,7 @@ import {getCorrectEventName} from '@material/animation'
 import {RippleBase} from '../util'
 
 export default {
+  name: 'mdc-checkbox',
   model: {
     prop: 'checked',
     event: 'change'

--- a/components/icon-toggle/mdc-icon-toggle.vue
+++ b/components/icon-toggle/mdc-icon-toggle.vue
@@ -14,6 +14,7 @@ import MDCIconToggleFoundation from '@material/icon-toggle/foundation'
 import {RippleBase} from '../util'
 
 export default {
+  name: 'mdc-icon-toggle',
   props: {
     'toggle-on': String,
     'toggle-off': String,

--- a/components/layout-grid/mdc-layout-cell.vue
+++ b/components/layout-grid/mdc-layout-cell.vue
@@ -15,6 +15,7 @@ const spanOptions = {
 }
 
 export default {
+  name: 'mdc-layout-cell',
   props: {
     span: spanOptions,
     order: spanOptions,

--- a/components/layout-grid/mdc-layout-grid.vue
+++ b/components/layout-grid/mdc-layout-grid.vue
@@ -9,6 +9,7 @@
 
 <script>
 export default {
+  name: 'mdc-layout-grid',
   props: {
     'fixed-column-width': Boolean
   },

--- a/components/linear-progress/mdc-linear-progress.vue
+++ b/components/linear-progress/mdc-linear-progress.vue
@@ -23,6 +23,7 @@ const ProgressPropType = {
 }
 
 export default {
+  name: 'mdc-linear-progress',
   props: {
     'open': { type: Boolean, default: true },
     'indeterminate': Boolean,

--- a/components/list/mdc-list-divider.vue
+++ b/components/list/mdc-list-divider.vue
@@ -4,6 +4,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-list-divider',
   props: {
     'inset': Boolean
   },

--- a/components/list/mdc-list-item.vue
+++ b/components/list/mdc-list-item.vue
@@ -22,6 +22,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-list-item',
   computed: {
     hasSecondary () {
       return !!this.$slots['secondary']

--- a/components/list/mdc-list.vue
+++ b/components/list/mdc-list.vue
@@ -8,6 +8,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-list',
   props: {
     'dense': Boolean,
     'avatar-list': Boolean,

--- a/components/menu/mdc-menu.vue
+++ b/components/menu/mdc-menu.vue
@@ -13,6 +13,7 @@ import {getTransformPropertyName} from '@material/menu/util'
 import {emitCustomEvent} from '../util'
 
 export default {
+  name: 'mdc-menu',
   props: {
     'open-from-top-left': Boolean,
     'open-from-top-right': Boolean,

--- a/components/select/mdc-menu-option.vue
+++ b/components/select/mdc-menu-option.vue
@@ -9,6 +9,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-menu-option',
   props: {
     value: String,
     disabled: Boolean

--- a/components/select/mdc-menu-select.vue
+++ b/components/select/mdc-menu-select.vue
@@ -15,6 +15,7 @@
 import MDCSelectFoundation from '@material/select/foundation'
 
 export default {
+  name: 'mdc-menu-select',
   model: {
     prop: 'value',
     event: 'change'

--- a/components/select/mdc-multi-option.vue
+++ b/components/select/mdc-multi-option.vue
@@ -9,6 +9,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-multi-option',
   props: {
     value: String,
     disabled: Boolean

--- a/components/select/mdc-multi-select.vue
+++ b/components/select/mdc-multi-select.vue
@@ -13,6 +13,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-multi-select',
   model: {
     prop: 'value',
     event: 'change'

--- a/components/select/mdc-native-option.vue
+++ b/components/select/mdc-native-option.vue
@@ -9,6 +9,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-native-option',
   props: {
     value: String,
     disabled: Boolean

--- a/components/select/mdc-native-select.vue
+++ b/components/select/mdc-native-select.vue
@@ -9,6 +9,7 @@
 
 <script lang="babel">
 export default {
+  name: 'mdc-native-select',
   model: {
     prop: 'value',
     event: 'change'

--- a/components/select/mdc-option.vue
+++ b/components/select/mdc-option.vue
@@ -10,6 +10,7 @@ import MDCMenuOption from './mdc-menu-option.vue'
 import MDCMultiOption from './mdc-multi-option.vue'
 
 export default {
+  name: 'mdc-option',
   props: {
     value: String,
     disabled: Boolean

--- a/components/snackbar/mdc-snackbar.vue
+++ b/components/snackbar/mdc-snackbar.vue
@@ -15,6 +15,7 @@ import MDCSnackbarFoundation from '@material/snackbar/foundation'
 import { getCorrectEventName } from '@material/animation'
 
 export default {
+  name: 'mdc-snackbar',
   props: {
     'event': {
       type: String,

--- a/components/tabs/mdc-tab-bar.vue
+++ b/components/tabs/mdc-tab-bar.vue
@@ -11,6 +11,7 @@ import MDCTabBarFoundation from '@material/tabs/tab-bar/foundation'
 import MDCTabFoundation from '@material/tabs/tab/foundation'
 
 export default {
+  name: 'mdc-tab-bar',
   props: {
     'indicator-primary': Boolean,
     'indicator-accent': Boolean

--- a/components/textfield/mdc-textfield.vue
+++ b/components/textfield/mdc-textfield.vue
@@ -63,6 +63,7 @@ import MDCTextfieldFoundation from '@material/textfield/foundation'
 import {RippleBase} from '../util'
 
 export default {
+  name: 'mdc-textfield',
   props: {
     'value': String,
     'type': {


### PR DESCRIPTION
Vue-styleguidist requires `name` option in each Vue component to work.