### PR TITLE
Fixing mdc-tab-bar bar property reference

### DIFF
--- a/components/tabs/mdc-tab-bar.vue
+++ b/components/tabs/mdc-tab-bar.vue
@@ -60,7 +60,7 @@ export default {
       getOffsetWidthForIndicator: () =>
         this.$refs.indicator.offsetWidth,
       notifyChange: (evtData) => {
-        this.$emit('change', evtData.activeIndex)
+        this.$emit('change', evtData.activeTabIndex)
       },
       getNumberOfTabs: () =>
         this.tabs.length,


### PR DESCRIPTION
Fixing a reference to 'activeIndex' that should be 'activeTabIndex' so that when the @change event is fired it gets passed correctly.