### PR TITLE
docs(getting-started): fix examples of manually using VueMDCAdapter with Vue

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ npm run dev
 import Vue from 'vue'
 import 'vue-mdc-adapter/dist/vue-mdc-adapter.css'
 import VueMDCAdapter from 'vue-mdc-adapter'
-Vue.use(VueMdcAdapter)
+Vue.use(VueMDCAdapter)
 ```
 
 ## Getting Serious
@@ -149,7 +149,7 @@ npm install vue-mdc-adapter
 ```javascript
 import Vue from 'vue'
 import VueMDCAdapter from 'vue-mdc-adapter'
-Vue.use(VueMdcAdapter)
+Vue.use(VueMDCAdapter)
 ```
 
 #### import _a la carte_  plugins


### PR DESCRIPTION
The examples in the [getting started documentation](https://stasson.github.io/vue-mdc-adapter/#/docs/getting-started) lead to a syntax error (`'VueMdcAdapter' is not defined`) when they are simply copy/pasted from the doc.