### PR TITLE
feat(textfield): add icon component - DO NOT MERGE

### DIFF
--- a/components/textfield/mdc-textfield-icon.vue
+++ b/components/textfield/mdc-textfield-icon.vue
@@ -1,0 +1,40 @@
+<template>
+  <i class="material-icons mdc-text-field__icon"
+    @click="foundation.handleInteraction"
+    tabindex="0">{{ icon }}</i>
+</template>
+
+
+<script>
+import MDCTextFieldIconFoundation from "@material/textfield/icon/foundation";
+
+export default {
+  name: 'mdc-texfield-icon',
+  props: {
+    icon: {
+      type: String,
+      required: true
+    },
+    disabled: Boolean
+  },
+  data () {
+    return {
+      foundation: null
+    }
+  },
+  watch: {
+    disabled () {
+      this.foundation && this.foundation.setDisabled(this.disabled)
+    }
+  },
+  mounted () {
+    this.foundation = new MDCTextFieldIconFoundation({
+      setAttr: (attr, value) => this.$el.setAttribute(attr, value),
+      registerInteractionHandler: (evtType, handler) => this.$el.addEventListener(evtType, handler),
+      deregisterInteractionHandler: (evtType, handler) => this.$el.removeEventListener(evtType, handler),
+      notifyIconAction: () => this.$emit('MDCTextField:icon', this)
+    })
+  }
+}
+</script>
+

--- a/components/textfield/mdc-textfield.vue
+++ b/components/textfield/mdc-textfield.vue
@@ -63,9 +63,13 @@ import {
   emitCustomEvent, extractIconProp, 
   DispatchFocusMixin, CustomElementMixin} from '../base'
 import {RippleBase} from '../ripple'
+import MDCTextfieldIcon from './mdc-textfield-icon.vue'
 
 export default {
   name: 'mdc-textfield',
+  components: {
+    'mdc-textfield-icon': MDCTextfieldIcon
+  },
   mixins: [CustomElementMixin, DispatchFocusMixin],
   props: {
     value: String,


### PR DESCRIPTION
closes #174 

I didn't realize that the textfield icon wasn't included in the most recent release so I'll update this PR once MDC Web v0.28 is released.