### PR TITLE
docs(menu): fix wrong method name (open -> show)

### DIFF
--- a/components/menu/README.md
+++ b/components/menu/README.md
@@ -76,8 +76,8 @@ The anchor is a wrapper element that contains the actual visible element to atta
 
 ### Methods
 
-- `open({focusIndex: number} = {}) => void`  
-Opens the menu. Takes an options object containing a `focusIndex` property that 
+- `show({focusIndex: number} = {}) => void`  
+Shows the menu. Takes an options object containing a `focusIndex` property that 
 specifies the index of the menu item to be focused.
 If the options object or `focusIndex` is omitted, no menu item will be focused.
 


### PR DESCRIPTION
The doc for the [menu component](https://stasson.github.io/vue-mdc-adapter/#/component/menu) contains the wrong method name to show the menu.

![image](https://user-images.githubusercontent.com/576772/34457520-42258ae2-edb3-11e7-97ca-292908377b8c.png)
