### PR TITLE
fix(drawer-item): emit click event regardless of router link presence

### DIFF
--- a/components/drawer/mdc-drawer-item.vue
+++ b/components/drawer/mdc-drawer-item.vue
@@ -2,7 +2,7 @@
   <custom-link :link="link" 
     class="mdc-drawer-item mdc-list-item" 
     :class="classes" :style="styles"
-    @click.native="onClick">
+    @click="onClick">
     <span class="mdc-list-item__start-detail" v-if="hasStartDetail">
       <slot name="start-detail">
         <i class="material-icons" aria-hidden="true">{{startIcon}}</i>


### PR DESCRIPTION
I'm not exactly sure why this works but it certainly appears to fix the issue.

closes #206