### PR TITLE
feat(grid-list): Add interactive support

### DIFF
--- a/components/grid-list/README.md
+++ b/components/grid-list/README.md
@@ -5,7 +5,7 @@ Each item in a grid list is called a tile. Tiles maintain consistent width,
 height, and padding across screen sizes.
 
 ```html
-<mdc-grid-list with-support-text>
+<mdc-grid-list with-support-text interactive>
   <mdc-grid-tile ratio="16x9"  
     v-for="(item, index) in tiles" :key="index"
     :src="item.src"
@@ -49,6 +49,7 @@ var vm = new Vue({
 |`icon-align-start`| Boolean|| whether tiles have a start icon |
 |`icon-align-end`| Boolean|| whether tiles have an end icon |
 |`with-support-text`| Boolean|| whether tiles have support text |
+|`interactive`| Boolean|| set interactive style for hover, focus, and press states |
 
 #### mdc-grid-tile
 
@@ -59,7 +60,14 @@ var vm = new Vue({
 |`icon`|String|| icon name |
 |`title`|String|| title name |
 |`support-text`|String|| support text |
+|`activated`|Boolean|| styles the row in an activated state (*)|
+|`selected`|Boolean|| styles the row in a selected state (*)|
 
+> Note: the difference between selected and activated states:
+- Selected is ephemeral and likely to change soon. E.g., selecting one or more photos to share in Google Photos. Multiple items in a list can be selected at the same time.
+- Activated is more permanent within the page’s lifetime. E.g., the currently highlighted destination in a nav drawer. Only one item in a list can be activated at a time.
+
+> if the list is interactive, `mdc-grid-tile` will dispatch mouse and keyboard listeners (`@click`, ...)
 
 ### Image only tiles
 

--- a/components/grid-list/demo.vue
+++ b/components/grid-list/demo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="mdc-demo mdc-demo--container">
     <mdc-grid-list icon-align-start with-support-text width=150 
-      class="mdc-demo">
+      class="mdc-demo" interactive>
       <mdc-grid-tile :src="tile"
         :title="'Title ' + (index + 1)"
         support-text="support text" cover icon="star_border"

--- a/components/grid-list/mdc-grid-list.vue
+++ b/components/grid-list/mdc-grid-list.vue
@@ -39,8 +39,9 @@ export default {
       return classes
     },
     styles () {
+      var defaultWidth = 200
       return {
-        '--mdc-grid-list-tile-width': `${this.width}px`
+        '--mdc-grid-list-tile-width': `${this.width || defaultWidth}px`
       }
     }
   },

--- a/components/grid-list/mdc-grid-list.vue
+++ b/components/grid-list/mdc-grid-list.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="mdc-grid-list" :class="classes" :style=styles>
-    <ul class="mdc-grid-list__tiles">
-      <slot></slot>
+  <div class="mdc-grid-list">
+    <ul class="mdc-grid-list__tiles" :class="classes" :style=styles>
+        <slot></slot>
     </ul>
   </div>
 </template>
@@ -18,35 +18,31 @@ export default {
     'header-caption': Boolean,
     'icon-align-start': Boolean,
     'icon-align-end': Boolean,
-    'with-support-text': Boolean
+    'with-support-text': Boolean,
+    'interactive': Boolean
   },
-  data () {
-    let classes = {}
-    if (this.narrowGutter) {
-      classes['mdc-grid-list--tile-gutter-1'] = true
-    }
-    if (this.headerCaption) {
-      classes['mdc-grid-list--header-caption'] = true
-    }
-    if (this.ratio) {
-      classes[`mdc-grid-list--tile-aspect-${this.ratio}`] = true
-    }
-    if (this.iconAlignStart) {
-      classes['mdc-grid-list--with-icon-align-start'] = true
-    }
-    if (this.iconAlignEnd) {
-      classes['mdc-grid-list--with-icon-align-end'] = true
-    }
-    if (this.withSupportText) {
-      classes['mdc-grid-list--twoline-caption'] = true
-    }
+  provide () {
+    return { mdcGrid: this }
+  },
+  computed: {
+    classes () {
+      let classes = {}
 
-    let styles = {}
-    if (this.width) {
-      styles['--mdc-grid-list-tile-width'] = `${this.width}px`
-    }
+      classes['mdc-grid-list--tile-gutter-1'] = this.narrowGutter
+      classes['mdc-grid-list--header-caption'] = this.headerCaption
+      classes[`mdc-grid-list--tile-aspect-${this.ratio}`] = this.ratio
+      classes['mdc-grid-list--with-icon-align-start'] = this.iconAlignStart
+      classes['mdc-grid-list--with-icon-align-end'] = this.iconAlignEnd
+      classes['mdc-grid-list--twoline-caption'] = this.withSupportText
+      classes['mdc-grid-list--non-interactive'] = !this.interactive
 
-    return { classes, styles }
+      return classes
+    },
+    styles () {
+      return {
+        '--mdc-grid-list-tile-width': `${this.width}px`
+      }
+    }
   },
   mounted () {
     this.foundation = new MDCGridListFoundation({

--- a/components/grid-list/mdc-grid-tile.vue
+++ b/components/grid-list/mdc-grid-tile.vue
@@ -1,5 +1,8 @@
 <template>
-  <li class="mdc-grid-tile">
+  <li class="mdc-grid-tile" @click="onClick"
+    :class="[classes, itemClasses]" :style="styles"
+    :tabindex="isInteractive ? '0' : undefined"
+    v-on="isInteractive ? $listeners : {}">
     <div class="mdc-grid-tile__primary" v-if="cover">
       <div class="mdc-grid-tile__primary-content"
         :style="{ backgroundImage: 'url(' + src + ')' }">
@@ -16,15 +19,85 @@
   </li>
 </template>
 
+
 <script>
+import {DispatchEventMixin} from '../base'
+import {RippleBase} from '../ripple'
+
 export default {
   name: 'mdc-grid-tile',
+  inject: ['mdcGrid'],
+  mixins: [DispatchEventMixin],
   props: {
     'src': String,
     'cover': Boolean,
     'icon': String,
     'title': String,
     'support-text': String,
+    'selected': Boolean,
+    'activated': Boolean
+  },
+  data () {
+    return {
+      classes: {},
+      styles: {}
+    }
+  },
+  computed: {
+    itemClasses () {
+      return {
+        'mdc-grid-tile--selected': this.selected,
+        'mdc-grid-tile--activated': this.activated
+      }
+    },
+    isInteractive () {
+      return this.mdcGrid && this.mdcGrid.interactive
+    },
+    hasStartDetail () {
+      return this.startIcon || this.$slots['start-detail']
+    },
+    hasEndDetail () {
+      return this.endIcon || this.$slots['end-detail']
+    }
+  },
+  watch: {
+    isInteractive (value) {
+      if (value) {
+        this.addRipple()
+      } else {
+        this.removeRipple()
+      }
+    }
+  },
+  methods: {
+    onClick (evt) {
+      this.dispatchEvent(evt)
+    },
+    addRipple () {
+      if (!this.ripple) {
+        let ripple = new RippleBase(this)
+        ripple.init()
+        this.ripple = ripple
+      }
+    },
+    removeRipple () {
+      if (this.ripple) {
+        let ripple = this.ripple
+        this.ripple = null
+        ripple.destroy()
+      }
+    }
+  },
+  mounted () {
+    this.isInteractive && this.addRipple()
+    /* eslint-disable no-console */
+    console.log(this)
+    console.log(this.$el.getBoundingClientRect())
+    console.log(this.ripple)
+    /* eslint-enable no-console */
+  },
+  beforeDestroy () {
+    this.removeRipple()
   }
 }
 </script>

--- a/components/grid-list/mdc-grid-tile.vue
+++ b/components/grid-list/mdc-grid-tile.vue
@@ -90,11 +90,6 @@ export default {
   },
   mounted () {
     this.isInteractive && this.addRipple()
-    /* eslint-disable no-console */
-    console.log(this)
-    console.log(this.$el.getBoundingClientRect())
-    console.log(this.ripple)
-    /* eslint-enable no-console */
   },
   beforeDestroy () {
     this.removeRipple()

--- a/components/grid-list/styles.scss
+++ b/components/grid-list/styles.scss
@@ -1,1 +1,35 @@
 @import "@material/grid-list/mdc-grid-list";
+
+// Interactive support
+@import "@material/ripple/common";
+@import "@material/ripple/mixins";
+
+// Mixins
+@mixin mdc-grid-tile-primary-text-ink-color($color) {
+  @include mdc-theme-prop(color, $color);
+}
+
+@mixin mdc-grid-tile-graphic-ink-color($color) {
+  .mdc-grid-tile__primary-content {
+    @include mdc-theme-prop(color, $color);
+  }
+}
+
+.mdc-grid-tile--selected,
+.mdc-grid-tile--activated {
+  @include mdc-grid-tile-primary-text-ink-color(primary);
+  @include mdc-grid-tile-graphic-ink-color(primary);
+}
+
+:not(.mdc-grid-list--non-interactive) > .mdc-grid-tile {
+  cursor: pointer;
+  @include mdc-ripple-surface;
+  @include mdc-ripple-radius-bounded;
+  @include mdc-states;
+  @include mdc-states-activated(primary);
+  @include mdc-states-selected(primary);
+}
+
+.mdc-grid-tile {
+  overflow: hidden;
+}

--- a/components/grid-list/styles.scss
+++ b/components/grid-list/styles.scss
@@ -21,6 +21,10 @@
   @include mdc-grid-tile-graphic-ink-color(primary);
 }
 
+.mdc-grid-tile {
+  overflow: hidden;
+}
+
 :not(.mdc-grid-list--non-interactive) > .mdc-grid-tile {
   cursor: pointer;
   @include mdc-ripple-surface;
@@ -30,6 +34,3 @@
   @include mdc-states-selected(primary);
 }
 
-.mdc-grid-tile {
-  overflow: hidden;
-}


### PR DESCRIPTION
Added interactive support to grid-list items.

I'm listing products in a grid-list, and figured having the grid-list interactive would be better than hacking up a solution.

Any feedback is appreciated.

I will be building upon the grid-list component to follow some of the material guideline action specifications:
https://material.io/guidelines/components/grid-lists.html#grid-lists-usage