### PR TITLE
fix(mdc-select): Correct a typo in foundationLabel 

### DIFF
--- a/components/select/mdc-menu-select.vue
+++ b/components/select/mdc-menu-select.vue
@@ -253,9 +253,9 @@ export default {
     this.foundation = null;
     foundation.destroy();
 
-    let foundationLabel = this.foundationLabel;
-    this.foundationLabel = null;
-    foundationLabel.destroy();
+    let labelFoundation = this.labelFoundation;
+    this.labelFoundation = null;
+    labelFoundation.destroy();
 
     let bottomLineFoundation = this.bottomLineFoundation;
     this.bottomLineFoundation = null;


### PR DESCRIPTION
In the `beforeDestroy` function, an `undefined` property was calling the `destroy` function. This was throwing an `TypeError: Cannot read property 'destroy' of undefined`.