### PR TITLE
Remove unused importation from mdc-menu

### DIFF
--- a/components/menu/mdc-menu.vue
+++ b/components/menu/mdc-menu.vue
@@ -13,9 +13,7 @@
 import { MDCMenuFoundation } from '@material/menu/foundation';
 import { getTransformPropertyName } from '@material/menu/util';
 import { emitCustomEvent } from '../base';
-import { Corner } from '@material/menu/constants';
 
-export { Corner };
 export default {
   name: 'mdc-menu',
   props: {

--- a/components/select/mdc-menu-select.vue
+++ b/components/select/mdc-menu-select.vue
@@ -253,9 +253,9 @@ export default {
     this.foundation = null;
     foundation.destroy();
 
-    let foundationLabel = this.foundationLabel;
-    this.foundationLabel = null;
-    foundationLabel.destroy();
+    let labelFoundation = this.labelFoundation;
+    this.labelFoundation = null;
+    labelFoundation.destroy();
 
     let bottomLineFoundation = this.bottomLineFoundation;
     this.bottomLineFoundation = null;


### PR DESCRIPTION
Fix #326 

It will remove the error in the javascript console for: `named exports are not supported in *.vue files.`