### PR TITLE
feat(mdc-chip): Allow underlying events to be emitted as first class …

### DIFF
--- a/components/chips/README.md
+++ b/components/chips/README.md
@@ -26,18 +26,19 @@ mdc-chip is a compact element that allows a user to enter information or select 
 |                       |         |          | which allow a single selection from a set of options.           |
 | `filter`              | Boolean | optional | Optional. Indicates that the chips in the set are filter chips, |
 |                       |         |          | which allow a multiple selection from a set of options.         |
-| `event`               | String  | optional | optional event to emit on click                                 |
-| `event-target`        | Object  | vm.$root | optional event target, defaults to root bus                     |
-| `event-args`          | Array   | []       | optional event args                                             |
 | `leadingIcon`         | String  | optional | optional leading icon                                           |
 | `trailingIcon`        | String  | optional | optional trailing icon                                          |
 | `leadingIconClasses`  | Object  | optional | optional leading icon classes (font-awesome)                    |
 | `trailingIconClasses` | Object  | optional | optional trailing icon classes (font-awesome)                   |
 
-| event              | description                          |
-| ------------------ | ------------------------------------ |
-| @click             | emitted on chip interaction          |
-| @trailingIconClick | emitted on trailing icon interaction |
+| event                            | description                                        |
+| -------------------------------- | -------------------------------------------------- |
+| @click                           | emitted on chip interaction                        |
+| @trailingIconClick               | emitted on trailing icon interaction               |
+| @MDCChip:interaction             | emitted on chip interaction (will bubble)          |
+| @MDCChip:trailingIconInteraction | emitted on trailing icon interaction (will bubble) |
+
+> Note: Events emitted by `material-components-web` on `mdc-chip` interaction appear as normal `Vue` events (no need for the .native modifier) and also "bubble" so can be listened for on the `mdc-chip-set` element and will receive the `mdc-chip` instance in the `detail` property.
 
 ### Chips with icons
 

--- a/components/chips/mdc-chip-set.vue
+++ b/components/chips/mdc-chip-set.vue
@@ -1,7 +1,7 @@
 <template>
-  <div :class="classes">
+  <div :class="classes" v-on="$listeners">
     <slot></slot>
-  </div>  
+  </div>
 </template>
 
 <script>

--- a/components/chips/mdc-chip.vue
+++ b/components/chips/mdc-chip.vue
@@ -1,6 +1,6 @@
 <template>
-<div :class="classes" :style="styles" tabindex="0" >
-  <i ref="leadingIcon" class="mdc-chip__icon mdc-chip__icon--leading" 
+<div :class="classes" :style="styles" tabindex="0" v-on="$listeners">
+  <i ref="leadingIcon" class="mdc-chip__icon mdc-chip__icon--leading"
     :class="leadingClasses" v-if="haveleadingIcon"
   >{{leadingIcon}}</i>
   <div class="mdc-chip__checkmark" v-if="isFilter">
@@ -12,7 +12,7 @@
   <div class="mdc-chip__text">
     <slot></slot>
   </div>
-  <i ref="trailingIcon" class="mdc-chip__icon mdc-chip__icon--trailing" tabindex="0" role="button" 
+  <i ref="trailingIcon" class="mdc-chip__icon mdc-chip__icon--trailing" tabindex="0" role="button"
     :class="trailingClasses" v-if="havetrailingIcon"
   >{{trailingIcon}}</i>
 </div>
@@ -20,12 +20,12 @@
 
 <script>
 import MDCChipFoundation from '@material/chips/chip/foundation';
-import { CustomLinkMixin, DispatchEventMixin, emitCustomEvent } from '../base';
+import { CustomLinkMixin, emitCustomEvent } from '../base';
 import { RippleBase } from '../ripple';
 
 export default {
   name: 'mdc-chip',
-  mixins: [CustomLinkMixin, DispatchEventMixin],
+  mixins: [CustomLinkMixin],
   props: {
     leadingIcon: [String],
     trailingIcon: [String],
@@ -68,7 +68,6 @@ export default {
       deregisterEventHandler: (evtType, handler) =>
         this.$el.removeEventListener(evtType, handler),
       notifyInteraction: () => {
-        this.dispatchEvent({ type: 'click' });
         emitCustomEvent(
           this.$el,
           MDCChipFoundation.strings.INTERACTION_EVENT,
@@ -79,7 +78,7 @@ export default {
         );
       },
       notifyTrailingIconInteraction: () => {
-        this.dispatchEvent({ type: 'trailingIconClick' });
+        this.$emit('trailingIconClick');
         emitCustomEvent(
           this.$el,
           MDCChipFoundation.strings.TRAILING_ICON_INTERACTION_EVENT,


### PR DESCRIPTION
…Vue events.

BREAKING CHANGE: Remove event target allowing material-components-web
and click events to be used as Vue events (no .native modifier
required).