### PR TITLE
feat(top-app-bar): Add tabs slot.

### DIFF
--- a/components/top-app-bar/README.md
+++ b/components/top-app-bar/README.md
@@ -72,6 +72,23 @@ Short top app bars can be configured to always appear collapsed by applying the 
 
 refer to the [MDC Documentation](https://material.io/components/web/catalog/toolbar/#flexible-toolbar-requires-javascript) to learn about customization options.
 
+### Tab Bar Row
+
+* `mdc-top-app-bar` has an additional available slot for use when creating a
+  top bar combined w/ top tabs, named `tabs`.
+
+
+```html
+<mdc-top-app-bar title="Title" event="nav" dense>
+    <mdc-top-app-bar-action @click="show-help" icon="help"></mdc-top-app-bar-action>
+    <mdc-top-app-bar-action @click="do-download" icon="file_download"></mdc-top-app-bar-action>
+    <mdc-tab-bar slot="tabs">
+      <mdc-tab to="/dogs">Dogs</mdc-tab>
+      <mdc-tab to="/cats">Cats</mdc-tab>
+    </mdc-tab-bar>
+</mdc-top-app-bar>
+```
+
 ### Reference
 
 * <https://material.io/components/web/catalog/top-app-bar>

--- a/components/top-app-bar/mdc-top-app-bar.vue
+++ b/components/top-app-bar/mdc-top-app-bar.vue
@@ -22,6 +22,11 @@
         <slot/>
       </section>
     </div>
+    <div
+      v-if="$slots.tabs"
+      class="mdc-top-app-bar__row">
+      <slot name="tabs"/>
+    </div>
   </header>
 </template>
 


### PR DESCRIPTION
In order to implement the "tabs joined w/ top app bar" as described in https://material.io/design/components/tabs.html#placement it seems like we need the ability to add another slot to top-app-bar for an `mdc-tab-bar` component, nested inside a "row" for the top app bar..

This patch does just that, but is very "tab-specific". If you'd rather something more generic, I'm happy to investigate how that might look.