### PR TITLE
fix "ReferenceError: window is not defined"

### DIFF
--- a/components/drawer/mdc-drawer.vue
+++ b/components/drawer/mdc-drawer.vue
@@ -114,7 +114,7 @@ export default {
     open: 'onOpen_'
   },
   created() {
-    if (window && window.matchMedia) {
+    if (typeof window !== 'undefined' && window.matchMedia) {
       this.small = media.small.matches
       this.large = media.large.matches
     }


### PR DESCRIPTION
In node environment (server-side rendering), this line would throw "window is not defined" error.