### PR TITLE
fix(top-app-bar): Don't wrap tabs slot in mdc-top-app-bar__row.

### DIFF
--- a/components/top-app-bar/mdc-top-app-bar.vue
+++ b/components/top-app-bar/mdc-top-app-bar.vue
@@ -22,11 +22,7 @@
         <slot/>
       </section>
     </div>
-    <div
-      v-if="$slots.tabs"
-      class="mdc-top-app-bar__row">
-      <slot name="tabs"/>
-    </div>
+    <slot name="tabs"/>
   </header>
 </template>
 


### PR DESCRIPTION
* __row element adds a fixed height that may conflict with the
  particular tab style (e.g. icons, just text), so we remove it.